### PR TITLE
Invoke python2 inside `configure` shebang (#8)

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import os


### PR DESCRIPTION
This pull request changes the python shebang line to use python2,
and fixes issues addressed in issue #8 regarding systems with either
python3 & python2 installed, or python 2 being explicitly named python2
(or python2.x).
